### PR TITLE
Sort list of input images before processing

### DIFF
--- a/time_stretch.py
+++ b/time_stretch.py
@@ -15,6 +15,7 @@ def main(debug=False):
         sys.exit(-1)
 
     images = list(os.listdir(IN_DIR))
+    images.sort()
 
     if len(images) == 0:
         exit(1)


### PR DESCRIPTION
`os.listdir` doesn't seem to always return the list of files in alphabetical order. On my computer, if I don't add this line, the program doesn't really work because the frames are totally out of order.